### PR TITLE
fix missing include and modules dir when building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Make.inc
 
 
-all:  objs lib
+all: libdir objs lib
 
 objs: amgp cbnd
 
@@ -15,9 +15,9 @@ libdir:
 	(if test ! -d modules ; then mkdir modules; fi;)	
 	($(INSTALL_DATA) Make.inc  include/Make.inc.amg4psblas)
         
-
 amgp:
 	cd amgprec && $(MAKE) objs
+
 cbnd: amgp
 	cd cbind && $(MAKE)  objs
 
@@ -39,6 +39,7 @@ install: lib
 	 	 mkdir -p  $(INSTALL_SAMPLESDIR)/advanced && \
 		(cd samples/simple; /bin/cp -fr pdegen fileread $(INSTALL_SAMPLESDIR)/simple ) && \
 		(cd samples/advanced; /bin/cp -fr pdegen fileread $(INSTALL_SAMPLESDIR)/advanced )
+
 cleanlib:
 	(cd lib; /bin/rm -f *.a *$(.mod) *$(.fh))
 	(cd include; /bin/rm -f *.a *$(.mod) *$(.fh))


### PR DESCRIPTION
When building I encountered the following error:

```
stefanopetrilli@server:~/repos/amg4psblas$ sudo make
cd amgprec && make objs
make[1]: Entering directory '/home/stefanopetrilli/repos/amg4psblas/amgprec'
mpifort -fallow-argument-mismatch -g -O3 -frecursive  -I. -I../include -I/home/stefanopetrilli/repos/psblas3/modules -I/home/stefanopetrilli/repos/psblas3/modules -I/home/stefanopetrilli/repos/psblas3/include -DHAVE_LAPACK -DHAVE_MOLD -DHAVE_EXTENDS_TYPE_OF -DHAVE_SAME_TYPE_AS -DHAVE_FLUSH_STMT -DMPI_MOD  -DHAVE_LAPACK -DHAVE_FLUSH_STMT -DLPK8 -DIPK4 -DMPI_MOD  -c amg_base_prec_type.F90 -o amg_base_prec_type.o
f951: Fatal Error: ‘../include’ is not a directory
compilation terminated.
make[1]: *** [/home/stefanopetrilli/repos/psblas3/include/Make.inc.psblas:84: amg_base_prec_type.o] Error 1
make[1]: Leaving directory '/home/stefanopetrilli/repos/amg4psblas/amgprec'
make: *** [Makefile:19: amgp] Error 2
```

To solve the error I changed the `make all` command in order to create the directories before they are needed.